### PR TITLE
chore: promote python-http to version 0.0.1

### DIFF
--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -6,11 +6,17 @@ environments:
 repositories:
 - name: jxgh
   url: https://jenkins-x-charts.github.io/repo
+- name: dev
+  url: http://chartmuseum-jx.35.239.51.71.nip.io
 releases:
 - chart: jxgh/jx-verify
   name: jx-verify
   namespace: jx-production
   values:
   - jx-values.yaml
+- chart: dev/python-http
+  version: 0.0.1
+  name: python-http
+  namespace: jx-production
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote python-http to version 0.0.1

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
