### PR TITLE
chore: promote jx-payments-manning to version 0.0.3

### DIFF
--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-gnykb-rb.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-gnykb-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-ahfy6
+  name: jx-verify-gc-jobs-gnykb
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-production

--- a/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-prspw-job.yaml
+++ b/config-root/namespaces/jx-production/jx-verify/jx-verify-gc-jobs-prspw-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-kkumh
+  name: jx-verify-gc-jobs-prspw
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-zuhyt
+    app: jx-verify-gc-jobs-gxzae
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production

--- a/config-root/namespaces/jx-staging/jx-payments-manning/jx-payments-manning-ingress.yaml
+++ b/config-root/namespaces/jx-staging/jx-payments-manning/jx-payments-manning-ingress.yaml
@@ -1,0 +1,22 @@
+# Source: jx-payments-manning/templates/ingress.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    meta.helm.sh/release-name: 'jx-payments-manning'
+  name: jx-payments-manning
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+spec:
+  rules:
+    - http:
+        paths:
+          - pathType: ImplementationSpecific
+            backend:
+              service:
+                name: jx-payments-manning
+                port:
+                  number: 80
+      host: jx-payments-manning-jx-staging.35.239.51.71.nip.io

--- a/config-root/namespaces/jx-staging/jx-payments-manning/jx-payments-manning-jx-payments-manning-deploy.yaml
+++ b/config-root/namespaces/jx-staging/jx-payments-manning/jx-payments-manning-jx-payments-manning-deploy.yaml
@@ -1,0 +1,60 @@
+# Source: jx-payments-manning/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jx-payments-manning-jx-payments-manning
+  labels:
+    draft: draft-app
+    chart: "jx-payments-manning-0.0.3"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-payments-manning'
+    wave.pusher.com/update-on-config-change: 'true'
+  namespace: jx-staging
+spec:
+  selector:
+    matchLabels:
+      app: jx-payments-manning-jx-payments-manning
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        draft: draft-app
+        app: jx-payments-manning-jx-payments-manning
+    spec:
+      serviceAccountName: jx-payments-manning-jx-payments-manning
+      containers:
+        - name: jx-payments-manning
+          image: "gcr.io/brifer-terraform-admin/jx-payments-manning:0.0.3"
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: VERSION
+              value: 0.0.3
+          envFrom: null
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            initialDelaySeconds: 60
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 8080
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          resources:
+            limits:
+              cpu: 400m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
+      terminationGracePeriodSeconds:
+      imagePullSecrets:

--- a/config-root/namespaces/jx-staging/jx-payments-manning/jx-payments-manning-jx-payments-manning-sa.yaml
+++ b/config-root/namespaces/jx-staging/jx-payments-manning/jx-payments-manning-jx-payments-manning-sa.yaml
@@ -1,0 +1,10 @@
+# Source: jx-payments-manning/templates/sa.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jx-payments-manning-jx-payments-manning
+  annotations:
+    meta.helm.sh/release-name: 'jx-payments-manning'
+  namespace: jx-staging
+  labels:
+    gitops.jenkins-x.io/pipeline: 'namespaces'

--- a/config-root/namespaces/jx-staging/jx-payments-manning/jx-payments-manning-svc.yaml
+++ b/config-root/namespaces/jx-staging/jx-payments-manning/jx-payments-manning-svc.yaml
@@ -1,0 +1,20 @@
+# Source: jx-payments-manning/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: jx-payments-manning
+  labels:
+    chart: "jx-payments-manning-0.0.3"
+    gitops.jenkins-x.io/pipeline: 'namespaces'
+  annotations:
+    meta.helm.sh/release-name: 'jx-payments-manning'
+  namespace: jx-staging
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP
+      name: http
+  selector:
+    app: jx-payments-manning-jx-payments-manning

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-85rcw-job.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-85rcw-job.yaml
@@ -2,12 +2,12 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: jx-verify-gc-jobs-bzxdg
+  name: jx-verify-gc-jobs-85rcw
   annotations:
     kapp.k14s.io/disable-wait: ""
     meta.helm.sh/release-name: 'jx-verify'
   labels:
-    app: jx-verify-gc-jobs-mc0xq
+    app: jx-verify-gc-jobs-c5guv
     release: jx-verify
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging

--- a/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-vmqp1-rb.yaml
+++ b/config-root/namespaces/jx-staging/jx-verify/jx-verify-gc-jobs-vmqp1-rb.yaml
@@ -2,7 +2,7 @@
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: jx-verify-gc-jobs-olwtt
+  name: jx-verify-gc-jobs-vmqp1
   annotations:
     meta.helm.sh/release-name: 'jx-verify'
   namespace: jx-staging

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,12 @@
 	      <td></td>
 	    </tr>
     <tr>
+	      <td><a href='' title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> jx-payments-manning </a></td>
+	      <td>0.0.3</td>
+	      <td></td>
+	      <td></td>
+	    </tr>
+    <tr>
 		      <td colspan='4'><h3>jx</h3></td>
 		    </tr>
 	    <tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -44,6 +44,18 @@
     repositoryUrl: http://chartmuseum-jx.35.239.51.71.nip.io
     resourcePath: config-root/namespaces/jx-staging/python-http
     version: 0.0.1
+  - apiVersion: v1
+    appVersion: 0.0.3
+    description: A Helm chart for Kubernetes
+    firstDeployed: "2022-01-21T02:58:17Z"
+    icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
+    lastDeployed: "2022-01-21T02:58:17Z"
+    logsUrl: https://console.cloud.google.com/logs/viewer?authuser=1&project=brifer-terraform-admin&minLogLevel=0&expandAll=false&customFacets=&limitCustomFacetWidth=true&interval=PT1H&resource=k8s_container%2Fcluster_name%2Ftf-jx-destined-dog%2Fnamespace_name%2Fjx-staging%2Fcontainer_name%2Fjx-payments-manning&dateRangeUnbound=both
+    name: jx-payments-manning
+    repositoryName: dev
+    repositoryUrl: http://chartmuseum-jx.35.239.51.71.nip.io
+    resourcePath: config-root/namespaces/jx-staging/jx-payments-manning
+    version: 0.0.3
 - namespace: jx
   path: helmfiles/jx/helmfile.yaml
   releases:

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -24,5 +24,7 @@ releases:
   version: 0.0.3
   name: jx-payments-manning
   namespace: jx-staging
+  values:
+  - jx-values.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -20,5 +20,9 @@ releases:
   namespace: jx-staging
   values:
   - jx-values.yaml
+- chart: dev/jx-payments-manning
+  version: 0.0.3
+  name: jx-payments-manning
+  namespace: jx-staging
 templates: {}
 renderedvalues: {}


### PR DESCRIPTION
chore: promote jx-payments-manning to version 0.0.3

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
